### PR TITLE
OG-52: Describe how to retrieve static grid information

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,18 @@ the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid
 
 #### 2.5.1 How to access the height of a grid point
 
-In the static HHL file one can obtain the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a wanted parameter to a specific height, follow the steps below.
-- Check if the `UUID` (Universally Unique Identifier) of the data file and the HHL file match.
-- Then, use the `scaledValueOfFirstFixedSurface` value to retrieve the height in meter above see level of the HHL file.
+In the static HHL file one can obtain the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a given parameter to a height in meters above sea level, follow the steps below.
+
+- Verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the HHL file match.
+- Obtain the value for the key `level` and check the key `typeOfLevel` by listing the GRIB messages. If `typeOfLevel` is
+    - **generalVertical**, the level number of the key `level` matches the half level in the HHL file and returns the height in meters above sea level.
+    - **generalVerticalLayer**, the level number of the key `level` corresponds to the full level. To retrieve the height in meters above sea level, the user has to take the average height of the two half levels above and below the full level.
+    - any other type of level, it is specified in meters and is self-explanatory.
 
 #### 2.5.2 How to access the longitude and latitude of a grid point
 
 The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid.
-### 🚧  **Temporary Notice Work in Progress **
+### 🚧  Temporary Notice Work in Progress
 When opening a data set in a jupyter notebook the load function includes fetching the CLON/CLAT values. To retrieve CLON/CLAT without a python environment, see section 2.7.
 
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ the horizontal grid, read section 2.1 in [Working with the ICON Model](https://w
 
 ### 2.5 Accessing Static Grid Information: Height, Longitude, and Latitude
 
+### 🚧  Temporary Notice Work in Progress
+
 Besides the current forecasting files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
 the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid. Note that the forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static files HHL and CLON/CLAT.
 
@@ -172,9 +174,7 @@ In the static HHL file one can obtain the height of the half levels of the verti
 
 #### 2.5.2 How to access the longitude and latitude of a grid point
 
-The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid.
-### 🚧  Temporary Notice Work in Progress
-When retrieving a data file in a jupyter notebook the load function includes fetching the CLON/CLAT values. To retrieve CLON/CLAT without a python environment, follow the septs below.
+The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. When retrieving a data file in a jupyter notebook the load function includes fetching the CLON/CLAT values. To retrieve CLON/CLAT without a python environment, follow the septs below.
 
 - Verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the CLON/CLAT file match.
 - To each value of the data set attach the longitude from the GRIB message with the `shortName` tlon and the latitude from the GRIB message with the `shortName` tlat. Values at the same position corresond to each other.

--- a/README.md
+++ b/README.md
@@ -281,17 +281,15 @@ curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.og
 ```
 wget -O <desired_filename> “<pre-signed URL>”
 ```
-- Once the static GRIB file is downloaded verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the HHL file match.
-- Obtain the value for the key `level` and check the key `typeOfLevel` by listing the GRIB messages. If `typeOfLevel` is
-    - **generalVertical**, the level number of the key `level` matches the half level in the HHL file and returns the height in meters above sea level.
-    - **generalVerticalLayer**, the level number of the key `level` corresponds to the full level. To retrieve the height in meters above sea level, the user has to take the average height of the two half levels above and below the full level.
-    - any other type of level, it is specified in meters and is self-explanatory.
-
->❗ **NOTE**: Values at the same position refer to the same grid point.
+- Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key of the data file and the HHL file match.
+- Retrieve the value for the `level` key and inspect the `typeOfLevel` key by listing the GRIB messages. If `typeOfLevel` is
+    - **generalVertical**: The value of `level` corresponds directly to a half level in the HHL file and gives the height in meters above sea level.
+    - **generalVerticalLayer**, **generalVerticalLayer**: The `level` value corresponds to a full level. To obtain the height in meters above sea level, average the heights of the two surrounding half levels (above and below).
+    - **Other types of level**: These are usually specified directly in meters and are self-explanatory.
 
 #### 2.7.2 Accessing Horizontal Grid Parameters
 
-The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. To retrieve CLON/CLAT coordinates follow the septs below.
+The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. To retrieve CLON/CLAT manually, follow the septs below.
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
@@ -302,10 +300,11 @@ curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.og
 ```
 wget -O <desired_filename> “<pre-signed URL>”
 ```
-- Once the static GRIB file is downloaded verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the CLON/CLAT file match.
-- To each value of the data set attach the longitude from the GRIB message with the `shortName` tlon and the latitude from the GRIB message with the `shortName` tlat. Values at the same position corresond to each other.
-
->❗ **NOTE**: Values at the same position refer to the same grid point.
+- Once the static GRIB file is downloaded, ensure that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the CLON/CLAT file
+- For each data value, attach the corresponding:
+    - Longitude from the GRIB message with `shortName = tlon`
+    - Latitude from the GRIB message with `shortName = tlat`
+Values at the same position corresond to each other.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ wget -O <desired_filename> “<pre-signed URL>”
 
 #### 2.7.2 Accessing Horizontal Grid Parameters
 
-The CLON/CLAT file stores the longitude and latitude of the center points of each triangle in the horizontal grid. To retrieve CLON/CLAT manually, follow the septs below.
+The CLON/CLAT file stores the longitude and latitude of the center points of each triangle in the horizontal grid. To retrieve CLON/CLAT, follow the steps below:
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The documentation covers the following topics:
 - [2.5 🚀 Run Notebooks](#25-🚀-run-notebooks)
 - [2.6 Retrieving Forecasts via REST API](#26-retrieving-forecasts-via-rest-api)
 - [2.7 Accessing Static Grid Information: Height, Longitude, and Latitude](#27-accessing-static-grid-information-height-longitude-and-latitude)
+- [2.8 Reading Forecast Files Using ecCodes](#28-reading-forecast-files-using-eccodes)
 
 ### 2.1 Model Specifications
 
@@ -200,67 +201,6 @@ wget -O <desired_filename> “<pre-signed URL>”
 ```
 Once downloaded, proceed with decoding the GRIB file using the instructions in [Section 2.7.4 Decoding GRIB Files with ecCodes](#274-decoding-grib-files-with-eccodes).
 
-#### 2.6.3 Installing ecCodes and COSMO definitions
-
-Once you have a GRIB file, you need a tool to read it. We recommend installing [ecCodes](https://confluence.ecmwf.int/display/UDOC/How+to+install+ecCodes+with+Python+bindings+in+conda+-+ecCodes+FAQ) from ECMWF.
-By default, the GRIB file shows the short names defined by ECMWF. However, the ICON model has its own definitions.
-In order to install them, apply the steps below.
-
-- Clone the GitHub repository [eccodes-cosmo-resources](https://github.com/COSMO-ORG/eccodes-cosmo-resources) into folder `<name_of_your_folder>`.
-- Clone the GitHub repository [ecmwf/eccodes](https://github.com/ecmwf/eccodes/) into the same folder `<name_of_your_folder>`.
-
-> ⚠️ **WARNING**:
-> Make sure both repositories are in the same folder and run on the same version.
-
-Finally, execute the following command to set the GRIB definition path:
-
-
-```
-export GRIB_DEFINITION_PATH=<name_of_your_folder>/eccodes-cosmo-recources/definitions:<name_of_your_folder>r/eccodes/definitions
-```
-
-> ❗ **NOTE**:
-> This command must be executed every time you start a new terminal session.
-
-#### 2.7.4 Decoding GRIB Files with ecCodes
-
-This section provides a brief introduction to decoding GRIB files using **ecCodes**.
-For more details, refer to the [ECMWF ecCodes documentation](https://events.ecmwf.int/event/363/contributions/4110/attachments/2346/4098/intro_grib_decoding_2023-10-31.pdf).
-
-Use the following commands to
-- Check ecCodes installation details:
-```
-codes_info
-```
-
-- List all the GRIB messages in a file:
-```
-grib_ls filename.grib
-```
-
-- Filter GRIB messages based on key-value conditions:
-```
-grib_ls -w key1=value1,key2=value2 filename.grib
-```
-
-- Specify a list of keys to be printed:
-```
-grib_ls -p key1,key2 filename.grib
-```
-
-- Get a detailed view of the content of all GRIB messages:
-```
-grib_dump filename.grib
-```
-- Get a detailed view of GRIB messages with filters:
-```
-grib_dump -w key1=value1,key2=value2 filename.grib
-```
-
-> ⚠️ **WARNING**:
-> Some variables in the ICON model are not included in the WMO standard definitions but are instead defined in ICON's local GRIB definitions. If a variable is missing, users should check the [eccodes-cosmo-resources files](https://github.com/COSMO-ORG/eccodes-cosmo-resources/blob/master/definitions/grib2/localConcepts/edzw/shortName.def).
-
-
 ### 2.7 Accessing Static Grid Information: Height, Longitude, and Latitude
 
 Besides the current forecasting files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
@@ -304,6 +244,69 @@ wget -O <desired_filename> “<pre-signed URL>”
 - For each data value, attach the corresponding:
     - Longitude from the GRIB message with `shortName = tlon`
     - Latitude from the GRIB message with `shortName = tlat`
+
+### 2.8 Reading Forecast Files Using ecCodes
+
+Once you have the desired GRIB files, you need a tool to read them. We recommend installing [ecCodes](https://confluence.ecmwf.int/display/UDOC/How+to+install+ecCodes+with+Python+bindings+in+conda+-+ecCodes+FAQ) from ECMWF.
+
+#### 2.8.1 Installing ecCodes and COSMO definitions
+
+By default, a GRIB file shows the short names defined by ECMWF. However, the ICON model has its own definitions.
+In order to install them, apply the steps below.
+
+- Clone the GitHub repository [eccodes-cosmo-resources](https://github.com/COSMO-ORG/eccodes-cosmo-resources) into folder `<name_of_your_folder>`.
+- Clone the GitHub repository [ecmwf/eccodes](https://github.com/ecmwf/eccodes/) into the same folder `<name_of_your_folder>`.
+
+> ⚠️ **WARNING**:
+> Make sure both repositories are in the same folder and run on the same version.
+
+Finally, execute the following command to set the GRIB definition path:
+
+
+```
+export GRIB_DEFINITION_PATH=<name_of_your_folder>/eccodes-cosmo-recources/definitions:<name_of_your_folder>r/eccodes/definitions
+```
+
+> ❗ **NOTE**:
+> This command must be executed every time you start a new terminal session.
+
+#### 2.8.2 Decoding GRIB Files with ecCodes
+
+This section provides a brief introduction to decoding GRIB files using **ecCodes**.
+For more details, refer to the [ECMWF ecCodes documentation](https://events.ecmwf.int/event/363/contributions/4110/attachments/2346/4098/intro_grib_decoding_2023-10-31.pdf).
+
+Use the following commands to
+- Check ecCodes installation details:
+```
+codes_info
+```
+
+- List all the GRIB messages in a file:
+```
+grib_ls filename.grib
+```
+
+- Filter GRIB messages based on key-value conditions:
+```
+grib_ls -w key1=value1,key2=value2 filename.grib
+```
+
+- Specify a list of keys to be printed:
+```
+grib_ls -p key1,key2 filename.grib
+```
+
+- Get a detailed view of the content of all GRIB messages:
+```
+grib_dump filename.grib
+```
+- Get a detailed view of GRIB messages with filters:
+```
+grib_dump -w key1=value1,key2=value2 filename.grib
+```
+
+> ⚠️ **WARNING**:
+> Some variables in the ICON model are not included in the WMO standard definitions but are instead defined in ICON's local GRIB definitions. If a variable is missing, users should check the [eccodes-cosmo-resources files](https://github.com/COSMO-ORG/eccodes-cosmo-resources/blob/master/definitions/grib2/localConcepts/edzw/shortName.def).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -266,11 +266,11 @@ grib_dump -w key1=value1,key2=value2 filename.grib
 Besides the current forecasting files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
 the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid.
 
-> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the vertical (HHL) and horizontal (CLON/CLAT) static GRIB files.
+> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical (HHL) and horizontal (CLON/CLAT) grid parameters file.
 
 #### 2.7.1 Accessing Vertical Grid Parameters
 
-The Vertical Grid Parameters file contains information about the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a given parameter to a height in meters above sea level, follow the steps below.
+The HHL file contains information about the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a given parameter to a height in meters above sea level, follow the steps below.
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
@@ -293,7 +293,7 @@ wget -O <desired_filename> “<pre-signed URL>”
 
 The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. To retrieve CLON/CLAT coordinates follow the septs below.
 
-- - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
+- Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
 curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The documentation covers the following topics:
 - [2.2 Available Parameters](#22-available-parameters)
 - [2.3 Accessing Forecast Data](#23-accessing-forecast-data)
 - [2.4 3D Grid Structure and Representation](#24-3d-grid-structure-and-representation)
-- [2.5 Example Notebooks: From Retrieval to Visualization](#25-🚀-example-notebooks-from-retrieval-to-visualization)
+- [2.5 Example Notebooks: From Retrieval to Visualization](#25-example-notebooks-from-retrieval-to-visualization)
 - [2.6 Retrieving Forecasts via REST API](#26-retrieving-forecasts-via-rest-api)
 - [2.7 Accessing Static Grid Information: Height, Longitude, and Latitude](#27-accessing-static-grid-information-height-longitude-and-latitude)
 - [2.8 Reading Forecast Files Using ecCodes](#28-reading-forecast-files-using-eccodes)

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Once downloaded, proceed with decoding the GRIB file using the instructions in [
 Besides the current forecast files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
 the center point coordinates of each triangle on the horizontal grid.
 
-> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical and horizontal grid parameter files.
+> ❗ **NOTE**: The forecast GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical and horizontal grid parameter files.
 
 #### 2.7.1 Accessing Vertical Grid Parameters
 
@@ -238,6 +238,8 @@ wget -O <desired_filename> “<pre-signed URL>”
 
 #### 2.7.2 Accessing Horizontal Grid Parameters
 
+> ❗ **NOTE**: We recommend inexperienced GRIB file users to take a look at the provided [Jupyter Notebooks](https://github.com/MeteoSwiss/opendata-nwp-demos). The data retrieval with the Python API includes fetching longitude and latitude.
+
 The static horizontal file stores the longitude and latitude of the center points of each triangle in the horizontal grid. To retrieve this information, follow the steps below:
 
 1. Submit a GET request specifying the collection you want to download the static horizontal files from (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
@@ -250,8 +252,6 @@ curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz
 wget -O <desired_filename> “<pre-signed URL>”
 ```
 4. Once the static GRIB file is downloaded, ensure that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the static horizontal file.
-
-> ❗ **NOTE**: We recommend inexperienced GRIB file users to take a look at the provided [Jupyter Notebooks](https://github.com/MeteoSwiss/opendata-nwp-demos). The data retrieval in the Notebooks includes fetching longitude and latitude.
 
 ### 2.8 Reading Forecast Files Using ecCodes
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ the center point coordinates of each triangle on the horizontal grid.
 
 #### 2.7.1 Accessing Vertical Grid Parameters
 
-In the static HHL file, the heights of the half levels of the vertical grid are provided in meters above see level. In order to associate a value from a data file (for a given parameter) to a height in meters above sea level, follow the steps below:
+In the static file, the heights of the half levels of the vertical grid are provided in meters above see level. In order to associate a value from a data file (for a given parameter) to a height in meters above sea level, follow the steps below:
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```

--- a/README.md
+++ b/README.md
@@ -215,42 +215,42 @@ Once downloaded, proceed with decoding the GRIB file using the instructions in [
 Besides the current forecast files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
 the center point coordinates of each triangle on the horizontal grid.
 
-> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical (HHL) and horizontal (CLON/CLAT) grid parameters file.
+> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical and horizontal grid parameters file.
 
 #### 2.7.1 Accessing Vertical Grid Parameters
 
-In the static file, the heights of the half levels of the vertical grid are provided in meters above see level. In order to associate a value from a data file (for a given parameter) to a height in meters above sea level, follow the steps below:
+In the static vertical file, the heights of the half levels of the vertical grid are provided in meters above see level. In order to associate a value from a data file (for a given parameter) to a height in meters above sea level, follow the steps below:
 
-1. Submit a GET request specifying the collection you want to retrieve the static files from (e.g., `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS):
+1. Submit a GET request specifying the collection you want to retrieve the static vertical files from (e.g., `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS):
 ```
 curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
 ```
-- Locate under `assets` in `id: vertical_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
-- Download the file with:
+2. Locate under `assets` in `id: vertical_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
+3. Download the file with:
 ```
 wget -O <desired_filename> “<pre-signed URL>”
 ```
-- Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the HHL file.
-- Retrieve the value for the `level` key and inspect the `typeOfLevel` key by listing the GRIB messages:
+4. Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the HHL file.
+5. Retrieve the value for the `level` key and inspect the `typeOfLevel` key by listing the GRIB messages:
     - **generalVertical**: The value of `level` corresponds directly to a half level in the HHL file and gives the height in meters above sea level.
     - **generalVerticalLayer**: The `level` value corresponds to a full level. To obtain the height in meters above sea level, average the heights of the two surrounding half levels (above and below).
     - **Other types of level**: These are usually specified directly in meters and are self-explanatory.
 
 #### 2.7.2 Accessing Horizontal Grid Parameters
 
-The CLON/CLAT file stores the longitude and latitude of the center points of each triangle in the horizontal grid. To retrieve CLON/CLAT, follow the steps below:
+The static horizontal file stores the longitude and latitude of the center points of each triangle in the horizontal grid. To retrieve this information, follow the steps below:
 
-- Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
+1. Submit a GET request specifying the collection you want to download the static horizontal files from (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
 curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
 ```
-- Locate under `assets` in `id: horizontal_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
-- Download the file with:
+2. Locate under `assets` in `id: horizontal_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
+3. Download the file with:
 ```
 wget -O <desired_filename> “<pre-signed URL>”
 ```
-- Once the static GRIB file is downloaded, ensure that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the CLON/CLAT file
-- For each data value, attach the corresponding:
+4. Once the static GRIB file is downloaded, ensure that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the static horizontal file.
+5. For each data value, attach the corresponding:
     - Longitude from the GRIB message with `shortName = tlon`
     - Latitude from the GRIB message with `shortName = tlat`
 

--- a/README.md
+++ b/README.md
@@ -168,11 +168,16 @@ In the static HHL file one can obtain the height of the half levels of the verti
     - **generalVerticalLayer**, the level number of the key `level` corresponds to the full level. To retrieve the height in meters above sea level, the user has to take the average height of the two half levels above and below the full level.
     - any other type of level, it is specified in meters and is self-explanatory.
 
+❗ **NOTE**: Values at the same position refer to the same grid point.
+
 #### 2.5.2 How to access the longitude and latitude of a grid point
 
 The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid.
 ### 🚧  Temporary Notice Work in Progress
-When opening a data set in a jupyter notebook the load function includes fetching the CLON/CLAT values. To retrieve CLON/CLAT without a python environment, see section 2.7.
+When retrieving a data file in a jupyter notebook the load function includes fetching the CLON/CLAT values. To retrieve CLON/CLAT without a python environment, follow the septs below.
+
+- Verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the CLON/CLAT file match.
+- To each value of the data set attach the longitude from the GRIB message with the `shortName` tlon and the latitude from the GRIB message with the `shortName` tlat. Values at the same position corresond to each other.
 
 
 ### 2.6 Data Visualisation

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Once downloaded, proceed with decoding the GRIB file using the instructions in [
 Besides the current forecast files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
 the center point coordinates of each triangle on the horizontal grid.
 
-> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical and horizontal grid parameters file.
+> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical and horizontal grid parameter files.
 
 #### 2.7.1 Accessing Vertical Grid Parameters
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ The documentation covers the following topics:
 - [2.2 Available Parameters](#22-available-parameters)
 - [2.3 Accessing Forecast Data](#23-accessing-forecast-data)
 - [2.4 3D Grid Structure and Representation](#24-3d-grid-structure-and-representation)
-- [2.5 Accessing Static Grid Information: Height, Longitude, and Latitude](#25-accessing-static-grid-information-height-longitude-and-latitude)
-- [2.6 Data Visualisation](#26-data-visualisation)
-- [2.7 Retrieving Forecasts via REST API](#27-retrieving-forecasts-via-rest-api)
+- [2.5 🚀 Run Notebooks](#25-🚀-run-notebooks)
+- [2.6 Retrieving Forecasts via REST API](#26-retrieving-forecasts-via-rest-api)
+- [2.7 Accessing Static Grid Information: Height, Longitude, and Latitude](#27-accessing-static-grid-information-height-longitude-and-latitude)
 
 ### 2.1 Model Specifications
 
@@ -153,34 +153,8 @@ Illustration of the grid construction, Working with the ICON Model, Figure 2.1
 Since the provided data is given in the native grid, note that the grid points correspond to the **center of the circumcircle of each triangle** and **not** to the vertices. Therefore, the longitude and latitude are based in the middle of each triangle on the grid mentioned before. For more detailed information on
 the horizontal grid, read section 2.1 in [Working with the ICON Model](https://www.dwd.de/DE/leistungen/nwv_icon_tutorial/pdf_einzelbaende/icon_tutorial2024.pdf?__blob=publicationFile&v=3).
 
-### 2.5 Accessing Static Grid Information: Height, Longitude, and Latitude
 
-### 🚧  Temporary Notice Work in Progress
-
-Besides the current forecasting files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
-the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid. Note that the forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static files HHL and CLON/CLAT.
-
-#### 2.5.1 How to access the height of a grid point
-
-In the static HHL file one can obtain the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a given parameter to a height in meters above sea level, follow the steps below.
-
-- Verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the HHL file match.
-- Obtain the value for the key `level` and check the key `typeOfLevel` by listing the GRIB messages. If `typeOfLevel` is
-    - **generalVertical**, the level number of the key `level` matches the half level in the HHL file and returns the height in meters above sea level.
-    - **generalVerticalLayer**, the level number of the key `level` corresponds to the full level. To retrieve the height in meters above sea level, the user has to take the average height of the two half levels above and below the full level.
-    - any other type of level, it is specified in meters and is self-explanatory.
-
-❗ **NOTE**: Values at the same position refer to the same grid point.
-
-#### 2.5.2 How to access the longitude and latitude of a grid point
-
-The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. When retrieving a data file in a jupyter notebook the load function includes fetching the CLON/CLAT values. To retrieve CLON/CLAT without a python environment, follow the septs below.
-
-- Verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the CLON/CLAT file match.
-- To each value of the data set attach the longitude from the GRIB message with the `shortName` tlon and the latitude from the GRIB message with the `shortName` tlat. Values at the same position corresond to each other.
-
-
-### 2.6 🚀 Run Notebooks
+### 2.5 🚀 Run Notebooks
 <p>
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
   <img src="https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg" style="height: 52px; vertical-align: middle; padding-right: 20px;">
@@ -190,11 +164,11 @@ The CLON/CLAT file stores the longitude and latitude of the center points of eac
   </a>
 </p>
 
-### 2.7 Retrieving Forecasts via REST API
+### 2.6 Retrieving Forecasts via REST API
 
 If users prefer not to use the provided library to load the data, they can retrieve datasets directly via the [REST API](https://sys-data.int.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data/operation/getAsset) by following the step-by-step instructions in this section to obtain forecast data for specific models, variables, and other customizable parameters.
 
-#### 2.7.1 Submitting a POST Request
+#### 2.6.1 Submitting a POST Request
 
 Filtering and querying forecast data must be done using a **POST** request. To retrieve a forecast, use a tool like `curl` and send the request to the API endpoint:
 ```
@@ -218,7 +192,7 @@ Each parameter in the request body serves the following purpose:
 - `forecast:perturbed`: Boolean flag determining if the data is deterministic (`false`) or ensemble-based.
 - `forecast:horizon`: Defines the lead time of the forecast in ISO 8601 duration format (`P0DT00H00M00S` for instant data).
 
-#### 2.7.2 Downloading the Forecast Data
+#### 2.6.2 Downloading the Forecast Data
 Upon a successful request, the response will contain a dictionary of metadata, including forecast file links under the `assets` key. Locate the `href` field containing the pre-signed URL.
 Download the GRIB file using the following command:
 ```
@@ -226,7 +200,7 @@ wget -O <desired_filename> “<pre-signed URL>”
 ```
 Once downloaded, proceed with decoding the GRIB file using the instructions in [Section 2.7.4 Decoding GRIB Files with ecCodes](#274-decoding-grib-files-with-eccodes).
 
-#### 2.7.3 Installing ecCodes and COSMO definitions
+#### 2.6.3 Installing ecCodes and COSMO definitions
 
 Once you have a GRIB file, you need a tool to read it. We recommend installing [ecCodes](https://confluence.ecmwf.int/display/UDOC/How+to+install+ecCodes+with+Python+bindings+in+conda+-+ecCodes+FAQ) from ECMWF.
 By default, the GRIB file shows the short names defined by ECMWF. However, the ICON model has its own definitions.
@@ -286,6 +260,52 @@ grib_dump -w key1=value1,key2=value2 filename.grib
 > ⚠️ **WARNING**:
 > Some variables in the ICON model are not included in the WMO standard definitions but are instead defined in ICON's local GRIB definitions. If a variable is missing, users should check the [eccodes-cosmo-resources files](https://github.com/COSMO-ORG/eccodes-cosmo-resources/blob/master/definitions/grib2/localConcepts/edzw/shortName.def).
 
+
+### 2.7 Accessing Static Grid Information: Height, Longitude, and Latitude
+
+Besides the current forecasting files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
+the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid.
+
+> ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the vertical (HHL) and horizontal (CLON/CLAT) static GRIB files.
+
+#### 2.7.1 Accessing Vertical Grid Parameters
+
+The Vertical Grid Parameters file contains information about the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a given parameter to a height in meters above sea level, follow the steps below.
+
+- Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
+```
+curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
+```
+- Locate under `assets` in `id: vertical_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
+- Download the file with:
+```
+wget -O <desired_filename> “<pre-signed URL>”
+```
+- Once the static GRIB file is downloaded verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the HHL file match.
+- Obtain the value for the key `level` and check the key `typeOfLevel` by listing the GRIB messages. If `typeOfLevel` is
+    - **generalVertical**, the level number of the key `level` matches the half level in the HHL file and returns the height in meters above sea level.
+    - **generalVerticalLayer**, the level number of the key `level` corresponds to the full level. To retrieve the height in meters above sea level, the user has to take the average height of the two half levels above and below the full level.
+    - any other type of level, it is specified in meters and is self-explanatory.
+
+>❗ **NOTE**: Values at the same position refer to the same grid point.
+
+#### 2.7.2 Accessing Horizontal Grid Parameters
+
+The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. To retrieve CLON/CLAT coordinates follow the septs below.
+
+- - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
+```
+curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
+```
+- Locate under `assets` in `id: horizontal_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
+- Download the file with:
+```
+wget -O <desired_filename> “<pre-signed URL>”
+```
+- Once the static GRIB file is downloaded verify that the key `uuidOfHGrid` (Universally Unique Identifier) of the data file and the CLON/CLAT file match.
+- To each value of the data set attach the longitude from the GRIB message with the `shortName` tlon and the latitude from the GRIB message with the `shortName` tlat. Values at the same position corresond to each other.
+
+>❗ **NOTE**: Values at the same position refer to the same grid point.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ In the static HHL file, the heights of the half levels of the vertical grid are 
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
-curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
+curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
 ```
 - Locate under `assets` in `id: vertical_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
 - Download the file with:
@@ -243,7 +243,7 @@ The CLON/CLAT file stores the longitude and latitude of the center points of eac
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
-curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
+curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
 ```
 - Locate under `assets` in `id: horizontal_constants_icon-ch1-eps.grib2` the `href` field and copy the pre-signed URL.
 - Download the file with:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Once downloaded, proceed with decoding the GRIB file using the instructions in [
 
 ### 2.7 Accessing Static Grid Information: Height, Longitude, and Latitude
 
-Besides the current forecasting files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
+Besides the current forecast files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
 the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid.
 
 > ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical (HHL) and horizontal (CLON/CLAT) grid parameters file.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ the center point coordinates of each triangle on the horizontal grid.
 
 In the static file, the heights of the half levels of the vertical grid are provided in meters above see level. In order to associate a value from a data file (for a given parameter) to a height in meters above sea level, follow the steps below:
 
-- Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
+1. Submit a GET request specifying the collection you want to retrieve the static files from (e.g., `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS):
 ```
 curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1/assets
 ```

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid
 
 #### 2.7.1 Accessing Vertical Grid Parameters
 
-The HHL file contains information about the height of the half levels of the vertical grid in meters above see level. In order to point a value from the data file of a given parameter to a height in meters above sea level, follow the steps below.
+In the static HHL file, the heights of the half levels of the vertical grid are provided in meters above see level. In order to associate a value from a data file (for a given parameter) to a height in meters above sea level, follow the steps below:
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
@@ -281,15 +281,15 @@ curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.og
 ```
 wget -O <desired_filename> “<pre-signed URL>”
 ```
-- Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key of the data file and the HHL file match.
-- Retrieve the value for the `level` key and inspect the `typeOfLevel` key by listing the GRIB messages. If `typeOfLevel` is
+- Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the on in the HHL file.
+- Retrieve the value for the `level` key and inspect the `typeOfLevel` key by listing the GRIB messages:
     - **generalVertical**: The value of `level` corresponds directly to a half level in the HHL file and gives the height in meters above sea level.
-    - **generalVerticalLayer**, **generalVerticalLayer**: The `level` value corresponds to a full level. To obtain the height in meters above sea level, average the heights of the two surrounding half levels (above and below).
+    - **generalVerticalLayer**: The `level` value corresponds to a full level. To obtain the height in meters above sea level, average the heights of the two surrounding half levels (above and below).
     - **Other types of level**: These are usually specified directly in meters and are self-explanatory.
 
 #### 2.7.2 Accessing Horizontal Grid Parameters
 
-The CLON/CLAT file stores the longitude and latitude of the center points of each triangle on the horizontal grid. To retrieve CLON/CLAT manually, follow the septs below.
+The CLON/CLAT file stores the longitude and latitude of the center points of each triangle in the horizontal grid. To retrieve CLON/CLAT manually, follow the septs below.
 
 - Submit a GET request specifying which model's asset should be downloaded (eg. `ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS).
 ```
@@ -304,7 +304,6 @@ wget -O <desired_filename> “<pre-signed URL>”
 - For each data value, attach the corresponding:
     - Longitude from the GRIB message with `shortName = tlon`
     - Latitude from the GRIB message with `shortName = tlat`
-Values at the same position corresond to each other.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ When retrieving a data file in a jupyter notebook the load function includes fet
 
 ### 2.6 Data Visualisation
 
-See [jupyter-notebook examples]().
+See [jupyter-notebook examples](https://github.com/MeteoSwiss/opendata-nwp-demos).
 
 ### 2.7 Retrieving Forecasts via REST API
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ curl GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz.og
 ```
 wget -O <desired_filename> “<pre-signed URL>”
 ```
-- Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the on in the HHL file.
+- Once the static GRIB file is downloaded, verify that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the HHL file.
 - Retrieve the value for the `level` key and inspect the `typeOfLevel` key by listing the GRIB messages:
     - **generalVertical**: The value of `level` corresponds directly to a half level in the HHL file and gives the height in meters above sea level.
     - **generalVerticalLayer**: The `level` value corresponds to a full level. To obtain the height in meters above sea level, average the heights of the two surrounding half levels (above and below).

--- a/README.md
+++ b/README.md
@@ -250,9 +250,8 @@ curl -X GET https://sys-data.int.bgdi.ch/api/stac/v1/collections/ch.meteoschweiz
 wget -O <desired_filename> “<pre-signed URL>”
 ```
 4. Once the static GRIB file is downloaded, ensure that the `uuidOfHGrid` (Universally Unique Identifier) key in the data file matches the one in the static horizontal file.
-5. For each data value, attach the corresponding:
-    - Longitude from the GRIB message with `shortName = tlon`
-    - Latitude from the GRIB message with `shortName = tlat`
+
+> ❗ **NOTE**: We recommend inexperienced GRIB file users to take a look at the provided [Jupyter Notebooks](https://github.com/MeteoSwiss/opendata-nwp-demos). The data retrieval in the Notebooks includes fetching longitude and latitude.
 
 ### 2.8 Reading Forecast Files Using ecCodes
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Once downloaded, proceed with decoding the GRIB file using the instructions in [
 ### 2.7 Accessing Static Grid Information: Height, Longitude, and Latitude
 
 Besides the current forecast files, each catalog contains two static files. They store permanent information about the height of the half levels (HHL) in the vertical grid and
-the center point coordinates of each triangle (CLON/CLAT) on the horizontal grid.
+the center point coordinates of each triangle on the horizontal grid.
 
 > ❗ **NOTE**: The forecasting GRIB files contain no information on height, longitude and latitude. They have to be determined via the static vertical (HHL) and horizontal (CLON/CLAT) grid parameters file.
 


### PR DESCRIPTION
Users not working with the Python API won’t have direct access to the latitude, longitude and heights coordinates, as the data is delivered in the native ICON grid (unstructured). Therefore, they will need to manually download the grid parameters, which are available as assets within the ICON-CH1 and ICON-CH2 collections. This section outlines the steps required to do so

https://meteoswiss.atlassian.net/jira/software/c/projects/OG/boards/510?search=lat&selectedIssue=OG-52